### PR TITLE
do not return error if no `Last-Modified` header is present

### DIFF
--- a/urlfilecache.go
+++ b/urlfilecache.go
@@ -139,8 +139,9 @@ func ToCustomPathTTL(url, path string, ttl time.Duration) error {
 		return fmt.Errorf("bad HTTP response %s so trying previous copy instead", resp.Status)
 	}
 
-	lastModified, err := http.ParseTime(resp.Header.Get("Last-Modified"))
-	if err != nil {
+	header := resp.Header.Get("Last-Modified")
+	lastModified, err := http.ParseTime(header)
+	if header != "" && err != nil {
 		return fmt.Errorf("failed to parse Last-Modified header: %w", err)
 	}
 


### PR DESCRIPTION
this was the behavior before, where the parsing error was ignored
but now, it means that the parsing fails if the header is not present (is empty: `""`)
this adds a check to return parsing error only if the header is found, otherwise it continues with default `time.Time` (as a side effect, this probably means that we cache files without lastmod with the epoch timestamp, e. g. forever? which is likely why it was fixed in the first place? so we should probably add a logic that does not cache it if there is no last mod header instead?)